### PR TITLE
state update for swap

### DIFF
--- a/src/components/common/ActionButton/ActionButton.tsx
+++ b/src/components/common/ActionButton/ActionButton.tsx
@@ -1,5 +1,7 @@
 import {clsx} from "clsx";
-import {forwardRef, memo, ReactNode, RefObject, useCallback} from "react";
+
+import {forwardRef, memo, ReactNode, useCallback} from "react";
+
 import Loader from "@/src/components/common/Loader/Loader";
 
 import styles from "./ActionButton.module.css";

--- a/src/components/common/Loader/Loader.module.css
+++ b/src/components/common/Loader/Loader.module.css
@@ -1,16 +1,22 @@
 .loader {
   display: inline-block;
-  width: 17px;
-  height: 17px;
   border: 2px solid var(--background-primary);
   border-bottom-color: transparent;
   border-radius: 50%;
   box-sizing: border-box;
   animation: rotation 1s linear infinite;
+  width: 17px;
+  height: 17px;
 }
 
 .outlined {
   border: 2px solid var(--accent-primary);
+}
+
+.gray {
+  border: 2px solid var(--content-tertiary);
+  border-bottom-color: transparent;
+  animation: rotation 1s linear infinite;
 }
 
 @keyframes rotation {

--- a/src/components/common/Loader/Loader.tsx
+++ b/src/components/common/Loader/Loader.tsx
@@ -3,12 +3,17 @@ import {clsx} from "clsx";
 
 type Props = {
   variant?: "primary" | "secondary" | "outlined";
+  color?: "gray"; //Add more color options if required
 };
 
-const Loader = ({variant}: Props) => {
+const Loader = ({variant, color}: Props): JSX.Element => {
   return (
     <div
-      className={clsx(styles.loader, variant === "outlined" && styles.outlined)}
+      className={clsx(
+        styles.loader,
+        variant === "outlined" && styles.outlined,
+        color && styles[`${color}`],
+      )}
     />
   );
 };


### PR DESCRIPTION
closes #52 

Fixes and Improvements in Swap State Management:

Action Button State After Wallet Decline:
Fixed an issue where the action button incorrectly displayed "Waiting approval in wallet" after the user declined the transaction. It now appropriately resets to "Swap again."

Improved UX for Transaction Cost Query:
Addressed an issue where the action button waited for the transaction cost query to complete before showing "Enter amount" if the user deleted the sell input value during the query. The button now updates immediately to reflect the correct state.

Avoid Unnecessary Queries for Over-Credit Inputs:
Added logic to prevent unnecessary transaction cost queries when the entered value exceeds the credit balance.

Reset State After Swap/Review Rejection:
Fixed a bug where changing the input value to 0.000 after rejecting a swap/review still allowed the "Swap" option. The trigger swap function was modified to check this

Correct Initial Button State:
Ensured that the button displays "Enter amount" instead of "Review" when no input values are provided.

Loading Spinner Transition:
Added a transition to display the regular loading spinner on the green button when moving from an inactive to an active button state.

Button State After Input Removal Post-Swap:
Fixed a bug where the button incorrectly displayed "Swap" instead of "Enter amount" after input was removed post-swap.

Prevent NaN in Estimated Rate:
Resolved an issue where removing the input after a swap caused the estimated rate to display NaN.

Insufficient Balance Messaging:
Updated the button state for ETH-to-other asset trades when the balance is insufficient. The button now displays the standard "Insufficient balance" state instead of "Bridge more ETH."